### PR TITLE
Time is off by an hour. Implement quick fix.

### DIFF
--- a/_posts/2016-04-12-meedup.md
+++ b/_posts/2016-04-12-meedup.md
@@ -5,7 +5,7 @@ layout: post
 categories:
 - posts
 - meetups
-when: 2016-04-19T19:30:00-06:00
+when: 2016-04-19T18:30:00-06:00
 ---
 
 {% assign speakr = 'Anton Astashov' %}

--- a/_posts/2016-04-12-meedup.md
+++ b/_posts/2016-04-12-meedup.md
@@ -5,7 +5,7 @@ layout: post
 categories:
 - posts
 - meetups
-when: 2016-04-19T18:30:00-06:00
+when: 2016-04-19T19:30:00-05:00
 ---
 
 {% assign speakr = 'Anton Astashov' %}


### PR DESCRIPTION
Something is causing the time to be displayed off by one hour (8:30 instead of 7:30) even though it appears to be written correctly. I couldn't track that down right now, but I did this quick and dirty fix just to get it right on the page.

@aaronj1335 
@lawnsea 