### PR TITLE
Add http:// to speakurl to fix URL

### DIFF
--- a/_posts/2017-01-09-meetup.md
+++ b/_posts/2017-01-09-meetup.md
@@ -11,7 +11,7 @@ when: 2017-01-17T19:30:00-05:00
 {% assign speakr = 'Rachel Weil' %}
 {% assign handle = 'partytimeHXLNT' %}
 {% assign twiturl = 'https://twitter.com/partytimeHXLNT' %}
-{% assign speakurl = 'nobadmemories.com' %}
+{% assign speakurl = 'http://nobadmemories.com' %}
 {% assign avi = 'http://i.imgur.com/evW0eSi.jpg' %}
 
 Happy New Year everyone! Here's to fresh start. We're kicking the year off in


### PR DESCRIPTION
This fixes a broken anchor on austinjavascript.com. When clicking the URL it goes to http://austinjavascript.com/posts/meetups/2017/01/09/nobadmemories.com

This fixes that