### PR TITLE
Add Andrew as an organizer and let's go to lavaca st afterward

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,11 @@ people:
       full: Aaron Stacy
       short: Aaron
       avi: https://pbs.twimg.com/profile_images/3281266042/5069b845017701c465760d25ba54b83c_400x400.jpeg
+    drewml:
+      twitter: drewml
+      full: Andrew Levine
+      short: Andrew
+      avi: https://pbs.twimg.com/profile_images/950842904771284992/pZwj7Nim_400x400.jpg
   emeriti:
     joemccann:
       twitter: joemccann

--- a/_includes/give-em-the-business.html
+++ b/_includes/give-em-the-business.html
@@ -33,10 +33,10 @@
   </li>
 </ul>
 
-{% unless include.nogingerman or include.location == "gingerman" %}
+{% unless include.nolavacast or include.location == "lavacast" %}
 Afterwards, the discussion carries on a few blocks away at <a
-href="http://thegingerman.com/austin/">The Gingerman</a> where they have over
-70 beers on tap.
+href="https://lavacastdowntown.com/">Lavaca Street Bar</a> where they have food,
+drinks, and 12 revolving taps.
 {% endunless %}
 
 <p>


### PR DESCRIPTION
We talked about going to Cedar Door, but they're having a Service Industry Appreciation night. As tempting as it would be to make some hilarious service worker jokes, let's just go to Lavaca St.