### PR TITLE
Passing the torch, update organizers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,17 @@ twitter:
 
 people:
   organizers:
+    kkipp:
+      twitter: kevin_kipp
+      full: Kevin Kipp
+      short: Kevin
+      avi: https://pbs.twimg.com/profile_images/931552869915926528/sBpw-pNh_400x400.jpg
+    pcostanzo:
+      twitter: pcostanz
+      full: Patrick Costanzo
+      short: Patrick
+      avi: https://pbs.twimg.com/profile_images/1230181384641183747/SKvgTCZL_400x400.jpg
+  emeriti:
     lawnsea:
       twitter: lawnsea
       full: Lon Ingram
@@ -33,7 +44,6 @@ people:
       full: Andrew Levine
       short: Andrew
       avi: https://pbs.twimg.com/profile_images/950842904771284992/pZwj7Nim_400x400.jpg
-  emeriti:
     joemccann:
       twitter: joemccann
       full: Joe McCann
@@ -43,7 +53,7 @@ people:
       twitter: SlexAxton
       full: Alex Sexton
       short: Alex
-      avi: https://pbs.twimg.com/profile_images/653393861453045760/6paq641-_400x400.jpg
+      avi: https://pbs.twimg.com/profile_images/1034325028026769408/hz_G2I3L_400x400.jpg
     rebecca:
       twitter: rmurphey
       full: Rebecca Murphey

--- a/about/index.md
+++ b/about/index.md
@@ -21,7 +21,7 @@ If you'd like to get more details on the topcs, take a look at the [post archive
 
 ## How does it usually work?
 
-We typically meet on the 3<sup>rd</sup> Tuesday of each month downtown. We'll have a speaker or two, open things up for questions and discussion, and then head over to [The Gingerman][] to continue the festivities.
+We typically meet on the 3<sup>rd</sup> Tuesday of each month downtown. We'll have a speaker or two, open things up for questions and discussion, and then head over to [Lavaca Street Bar][] to continue the festivities.
 
 ## Anything else I should know?
 
@@ -29,10 +29,10 @@ Yes! We've work hard to build a community of people that treats eachother with *
 
 ## Who are these people?
 
-Austin JavaScript is made possible by th hard work and good will of many people, but there are a few in particular that you should feel free to reach out to if you've got any questions:
+Austin JavaScript is made possible by the hard work and good will of many people, but there are a few in particular that you should feel free to reach out to if you've got any questions:
 
 {% include people.html %}
 
 [post archives]: /archive/
-[The Gingerman]: http://thegingerman.com/austin/
+[Lavaca Street Bar]: https://lavacastdowntown.com/
 [our Code of Conduct]: /austinjs-code-of-conduct/

--- a/austinjs-code-of-conduct/index.md
+++ b/austinjs-code-of-conduct/index.md
@@ -13,8 +13,8 @@ All attendees, speakers, sponsors and volunteers at our meetup are required to a
 
 Contact an organizer in person or via e-mail:
 
-  * Rebecca Murphey rmurphey@gmail.com
-  * Lon Ingram lawnsea@gmail.com
+  * Kevin Kipp kevin.kipp@gmail.com
+  * Patrick Costanzo costanzo.patrick@gmail.com
 
 ## The Quick Version
 


### PR DESCRIPTION
Shuffle some organizer tiles around, fix a typo, update the after party location.