### PR TITLE
Add GitHub Actions workflow; resolves #113

### DIFF
--- a/.github/workflows/Eleventy Build.yml
+++ b/.github/workflows/Eleventy Build.yml
@@ -1,0 +1,34 @@
+name: Eleventy Build
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.1
+
+    - name: Install packages
+      run: npm ci
+
+    - name: Run npm build
+      run: npm run build
+
+    - name: Deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        publish_dir: ./_site


### PR DESCRIPTION
We still need to set up deploy keys (see: http://stedman.dev/2020/04/29/make-the-jump-from-jekyll-to-javascript/#set-up-deployment-keys) to make this work.